### PR TITLE
Add missing translation string

### DIFF
--- a/src/scripts/nls/de.js
+++ b/src/scripts/nls/de.js
@@ -49,6 +49,7 @@ define({
 	FETCH_TITLE_TIP: 'Leer für Auto-Titel',
 	NAME: 'Titel',
 	ADDRESS: 'Adresse',
+	PARENT: 'Enthalten in Ordner',
 	JANUARY: 'Januar',
 	FEBRUARY: 'Februar',
 	MARCH: 'März',

--- a/src/scripts/nls/en.js
+++ b/src/scripts/nls/en.js
@@ -49,6 +49,7 @@ define({
 	FETCH_TITLE_TIP: 'If this field is empty, the title of the feed will be used instead.',
 	NAME: 'Name',
 	ADDRESS: 'Address',
+	PARENT: 'Parent folder',
 	JANUARY: 'January',
 	FEBRUARY: 'February',
 	MARCH: 'March',


### PR DESCRIPTION
The feed property window shows a missing translation ("PARENT!:" for the parent folder of the feed):

![2020-06-20_121722](https://user-images.githubusercontent.com/13220647/85200530-799a2480-b2f8-11ea-822e-3a5194486d90.jpg)

Added the missing PARENT translation.