### PR TITLE
Add missing english & german translations for feed context menu

### DIFF
--- a/src/scripts/nls/de.js
+++ b/src/scripts/nls/de.js
@@ -35,6 +35,8 @@ define({
 	TRASH: 'Papierkorb',
 	MARK_ALL_AS_READ: 'Alle als gelesen markieren',
 	PROPERTIES: 'Eigenschaften',
+	REFETCH: 'Rücksetzen & neu abrufen',
+	OPENHOME: 'Feed-Webseite öffnen',
 	UNDELETE: 'Wiederherstellen',
 	NEXT_UNREAD: 'Nächste Ungelesene',
 	PREV_UNREAD: 'Vorherige Ungelesene',

--- a/src/scripts/nls/en.js
+++ b/src/scripts/nls/en.js
@@ -35,6 +35,8 @@ define({
 	TRASH: 'Trash',
 	MARK_ALL_AS_READ: 'Mark All As Read',
 	PROPERTIES: 'Properties',
+	REFETCH: 'Refetch',
+	OPENHOME: 'Open feed homepage',
 	UNDELETE: 'Undelete',
 	NEXT_UNREAD: 'Next Unread',
 	PREV_UNREAD: 'Previous Unread',


### PR DESCRIPTION
REFETCH and OPENHOME are not translated:

![2020-06-20_220412](https://user-images.githubusercontent.com/13220647/85210731-c571bb80-b342-11ea-8b64-17e07ae60744.jpg)

The PR adds missing translations for the feed context menu.

In german, "Refetch" could maybe be translated shortly as "Neuabruf" oder "Neu abrufen" (word-by-word translation: "new fetch"), but this can / may be misinterpreted as an normal feed update.
To make it clear that this menu item also resets the feed prior to an update, I suggest to add an "Rücksetzen" (= english "Reset") in front of "Neu abrufen". So, the german "Rücksetzen & neu abrufen" will translate word-by-word as "Reset & new fetch".
