### PR TITLE
Fix bug in RSSParser where feed relative links are not properly handled

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
   },
   "description": "RSS Reader",
   "manifest_version": 2,
-  "version": "2.22.0",
+  "version": "2.22.1",
   "background": {
     "page": "index.html"
   },


### PR DESCRIPTION
In some feeds ([example](https://www.fpgadeveloper.com/index.xml)) the `link`s are not absolute URLs containing the domain, so then the item's link looks like `chrome-extension://.../path-on-the-authors-site/`.

This PR fixes that issue. Tested on Opera 73.0.3856.344 on Windows 10 (but I doubt it matters).

By the way, I ran the `release` task...hope that was the intention?