### PR TITLE
Add option to disable YouTube video preview

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -395,6 +395,11 @@
         </select>
       </label>
 
+      <label class="web-content-select-label">
+        <span class="selectLabel">Enable YouTube Preview:</span>
+        <input id="enableYoutubePreview" type="checkbox"/>
+      </label>
+
 <!--      <label class="web-content-select-label" title="If selected to see all articles hold alt or click on the counter">-->
 <!--        <span class="selectLabel">Show only unread articles by default:</span>-->
 <!--        <select id="defaultToUnreadOnly">-->

--- a/src/scripts/app/views/contentView.js
+++ b/src/scripts/app/views/contentView.js
@@ -260,6 +260,14 @@ define(function (require) {
                             audio.querySelector('source').src = enclosureData.url;
                             break;
                         case 'youtube':
+                            // Do not create YouTube Preview if disabled
+                            if (!bg.settings.get('enableYoutubePreview')) {
+                                newEnclosure = document
+                                    .createRange()
+                                    .createContextualFragment(require('text!templates/enclosureGeneral.html'));
+                                break;
+                            }
+
                             newEnclosure = document
                                 .createRange()
                                 .createContextualFragment(require('text!templates/enclosureYoutubeCover.html'));

--- a/src/scripts/bgprocess/models/Settings.js
+++ b/src/scripts/bgprocess/models/Settings.js
@@ -200,7 +200,8 @@ define(['backbone', 'preps/indexeddb'], function (BB) {
             invertColors: 'no',
             defaultView: 'feed',
             cacheParsedArticles: 'false',
-            defaultToUnreadOnly: 'false'
+            defaultToUnreadOnly: 'false',
+            enableYoutubePreview: true,
         },
         /**
          * @property localStorage


### PR DESCRIPTION
YouTube video previews seem to slow down my browser by a lot and I never use them.
Having the ability to disable this may be a benefit to all users who do not care about watching videos in the extension.
